### PR TITLE
making types more explicit (haskell)

### DIFF
--- a/haskell/msgpack.cabal
+++ b/haskell/msgpack.cabal
@@ -1,5 +1,5 @@
 Name:               msgpack
-Version:            0.4.0.1
+Version:            0.5.0.0
 Synopsis:           A Haskell binding to MessagePack
 Description:
   A Haskell binding to MessagePack <http://msgpack.org/>
@@ -37,6 +37,7 @@ Library
 
   Exposed-modules:
     Data.MessagePack
+    Data.MessagePack.Assoc
     Data.MessagePack.Pack
     Data.MessagePack.Unpack
     Data.MessagePack.Object

--- a/haskell/src/Data/MessagePack.hs
+++ b/haskell/src/Data/MessagePack.hs
@@ -13,6 +13,7 @@
 --------------------------------------------------------------------
 
 module Data.MessagePack(
+  module Data.MessagePack.Assoc,
   module Data.MessagePack.Pack,
   module Data.MessagePack.Unpack,
   module Data.MessagePack.Object,
@@ -44,6 +45,7 @@ import qualified Data.ByteString.Lazy as L
 import qualified Data.Iteratee as I
 import System.IO
 
+import Data.MessagePack.Assoc
 import Data.MessagePack.Pack
 import Data.MessagePack.Unpack
 import Data.MessagePack.Object

--- a/haskell/src/Data/MessagePack/Assoc.hs
+++ b/haskell/src/Data/MessagePack/Assoc.hs
@@ -1,0 +1,28 @@
+{-# Language DeriveDataTypeable #-}
+{-# Language GeneralizedNewtypeDeriving #-}
+
+--------------------------------------------------------------------
+-- |
+-- Module    : Data.MessagePack.Assoc
+-- Copyright : (c) Daiki Handa, 2010
+-- License   : BSD3
+--
+-- Maintainer:  tanaka.hideyuki@gmail.com
+-- Stability :  experimental
+-- Portability: portable
+--
+-- MessagePack map labeling type
+--
+--------------------------------------------------------------------
+
+module Data.MessagePack.Assoc (
+  Assoc(..)
+  ) where
+
+import Control.DeepSeq
+import Data.Typeable
+
+-- not defined for general Functor for performance reason.
+-- (ie. you would want to write custom instances for each type using specialized mapM-like functions)
+newtype Assoc a=Assoc{unAssoc :: a} deriving(Show,Eq,Ord,Typeable,NFData)
+

--- a/haskell/test/Test.hs
+++ b/haskell/test/Test.hs
@@ -7,6 +7,9 @@ import qualified Data.ByteString.Char8 as B
 import qualified Data.ByteString.Lazy.Char8 as L
 import Data.MessagePack
 
+instance Arbitrary a => Arbitrary (Assoc a) where
+  arbitrary = liftM Assoc arbitrary
+
 mid :: (Packable a, Unpackable a) => a -> a
 mid = unpack . pack
 
@@ -36,10 +39,12 @@ prop_mid_pair4 a = a == mid a
   where types = a :: (Int, Int, Int, Int)
 prop_mid_pair5 a = a == mid a
   where types = a :: (Int, Int, Int, Int, Int)
-prop_mid_map_int_double a = a == mid a
+prop_mid_list_int_double a = a == mid a
   where types = a :: [(Int, Double)]
-prop_mid_map_string_string a = a == mid a
+prop_mid_list_string_string a = a == mid a
   where types = a :: [(String, String)]
+prop_mid_map_string_int a = a == mid a
+  where types = a :: Assoc [(String,Int)]
 
 tests =
   [ testGroup "simple"
@@ -56,8 +61,9 @@ tests =
     , testProperty "(int, int, int)" prop_mid_pair3
     , testProperty "(int, int, int, int)" prop_mid_pair4
     , testProperty "(int, int, int, int, int)" prop_mid_pair5
-    , testProperty "[(int, double)]" prop_mid_map_int_double
-    , testProperty "[(string, string)]" prop_mid_map_string_string
+    , testProperty "[(int, double)]" prop_mid_list_int_double
+    , testProperty "[(string, string)]" prop_mid_list_string_string
+    , testProperty "Assoc [(string, int)]" prop_mid_map_string_int
     ]
   ]
 


### PR DESCRIPTION
1. +Assoc to label maps
   Previously, [(a,b)] and Vector (a,b) is automatically assumed to be maps, which is inconvenient when
   you want to unpack, for example, vector<tuple<int,int>>.
   With Assoc, [a] and Vector a will be always array, and you'll need to explicitly choose map.
   cf. http://twitter.com/#!/tanakh/status/19331914208903168
2. +ObjectFloat constructor in Object
   with only ObjectDouble, you can unpack Float but you cannot pack it.
   By adding ObjectFloat (and Packable Float), you'll be able to pack Floats.
   As a side effect, you can no longer unpack float with Double.
