### PR TITLE
テストのLDFLAGSに-pthread追加

### DIFF
--- a/cpp/test/Makefile.am
+++ b/cpp/test/Makefile.am
@@ -1,7 +1,7 @@
 
 AM_CPPFLAGS   = -I../src
 AM_C_CPPFLAGS = -I../src
-AM_LDFLAGS = ../src/libmsgpack.la -lgtest_main
+AM_LDFLAGS = ../src/libmsgpack.la -lgtest_main -pthread
 
 check_PROGRAMS = \
 		zone \


### PR DESCRIPTION
Ubuntu 10.10 x86_64 において、aptでインストールされるgoogle test(libgtest0パッケージ)はpthreadを必要とするようなので、cpp/test/Makefile.amのLDFLAGSに-pthreadを追加しました。
