### PR TITLE
Moved ZEND_DECLARE_MODULE_GLOBALS out of the header file. (PHP extension)

### DIFF
--- a/php/msgpack.c
+++ b/php/msgpack.c
@@ -19,6 +19,8 @@
 #include "msgpack_errors.h"
 #include "msgpack/version.h"
 
+ZEND_DECLARE_MODULE_GLOBALS(msgpack)
+
 static ZEND_FUNCTION(msgpack_serialize);
 static ZEND_FUNCTION(msgpack_unserialize);
 

--- a/php/msgpack_class.c
+++ b/php/msgpack_class.c
@@ -8,6 +8,8 @@
 #include "msgpack_convert.h"
 #include "msgpack_errors.h"
 
+ZEND_EXTERN_MODULE_GLOBALS(msgpack)
+
 typedef struct {
     zend_object object;
     long php_only;

--- a/php/msgpack_convert.c
+++ b/php/msgpack_convert.c
@@ -5,6 +5,8 @@
 #include "msgpack_convert.h"
 #include "msgpack_errors.h"
 
+ZEND_EXTERN_MODULE_GLOBALS(msgpack)
+
 #if (PHP_MAJOR_VERSION == 5 && PHP_MINOR_VERSION < 3)
 #   define Z_REFCOUNT_P(pz)    ((pz)->refcount)
 #   define Z_SET_ISREF_P(pz)   (pz)->is_ref = 1

--- a/php/msgpack_pack.c
+++ b/php/msgpack_pack.c
@@ -9,6 +9,8 @@
 #include "msgpack_pack.h"
 #include "msgpack_errors.h"
 
+ZEND_EXTERN_MODULE_GLOBALS(msgpack)
+
 #include "msgpack/pack_define.h"
 #define msgpack_pack_user smart_str*
 #define msgpack_pack_inline_func(name) \

--- a/php/msgpack_unpack.c
+++ b/php/msgpack_unpack.c
@@ -8,6 +8,8 @@
 #include "msgpack_unpack.h"
 #include "msgpack_errors.h"
 
+ZEND_EXTERN_MODULE_GLOBALS(msgpack)
+
 #if (PHP_MAJOR_VERSION == 5 && PHP_MINOR_VERSION < 3)
 #   define Z_ADDREF_PP(ppz)      ZVAL_ADDREF(*(ppz))
 #   define Z_SET_ISREF_PP(ppz)   (*(ppz))->is_ref = 1

--- a/php/php_msgpack.h
+++ b/php/php_msgpack.h
@@ -26,8 +26,6 @@ ZEND_BEGIN_MODULE_GLOBALS(msgpack)
     zend_bool php_only;
 ZEND_END_MODULE_GLOBALS(msgpack)
 
-ZEND_DECLARE_MODULE_GLOBALS(msgpack)
-
 #ifdef ZTS
 #define MSGPACK_G(v) TSRMG(msgpack_globals_id, zend_msgpack_globals *, v)
 #else


### PR DESCRIPTION
Hi,

I have moved ZEND_DECLARE_MODULE_GLOBALS into the msgpack.c file and added ZEND_EXTERN_MODULE_GLOBALS in source files that reference global variables.

This fixes linker error I received when compiling PHP module:

```
ld: duplicate symbol _msgpack_globals in .libs/msgpack_pack.o and .libs/msgpack.o 
```
