### PR TITLE
Fix all unaligned writes on ARM platform

### DIFF
--- a/msgpack/sysdep.h
+++ b/msgpack/sysdep.h
@@ -141,9 +141,25 @@ typedef unsigned int _msgpack_atomic_counter_t;
 	do { uint64_t val = _msgpack_be64(num); memcpy(to, &val, 8); } while(0)
 
 
-#define _msgpack_load16(cast, from) ((cast)_msgpack_be16(*(uint16_t*)from))
-#define _msgpack_load32(cast, from) ((cast)_msgpack_be32(*(uint32_t*)from))
-#define _msgpack_load64(cast, from) ((cast)_msgpack_be64(*(uint64_t*)from))
+#define _msgpack_load16(cast, from) ((cast)_msgpack_be16( \
+                                                         (((uint8_t*)from)[1] << 8) | ((uint8_t*)from)[0]))
+
+#define _msgpack_load32(cast, from) ((cast)_msgpack_be32(               \
+                                                         (((uint8_t*)from)[3] << 24) | \
+                                                         (((uint8_t*)from)[2] << 16) | \
+                                                         (((uint8_t*)from)[1] <<  8) | \
+                                                         (((uint8_t*)from)[0]      ) ))
+
+#define _msgpack_load64(cast, from) ((cast)_msgpack_be64( \
+  (((uint64_t)(((uint8_t*)from)[7])) << 56) |               \
+  (((uint64_t)(((uint8_t*)from)[6])) << 48) |               \
+  (((uint64_t)(((uint8_t*)from)[5])) << 40) |               \
+  (((uint64_t)(((uint8_t*)from)[4])) << 32) |               \
+  (((uint64_t)((uint8_t*)from)[3]) << 24) |                 \
+  (((uint64_t)((uint8_t*)from)[2]) << 16) |                 \
+  (((uint64_t)((uint8_t*)from)[1]) << 8) |                  \
+  (((uint8_t*)from)[0]      )))
+
 
 
 #endif /* msgpack/sysdep.h */


### PR DESCRIPTION
I made changes in msgpack library to  run it on ARM platform. Now all tests run on this platform successfully. 

Before the changes, 5 of the tests crashed with "Alignment trap" error.
