### PR TITLE
Fixes for VisualStudio compiler errors, issue #60.

### DIFF
--- a/python/msgpack/pack.h
+++ b/python/msgpack/pack.h
@@ -25,6 +25,10 @@
 extern "C" {
 #endif
 
+#ifdef _MSC_VER
+#define inline __inline
+#endif
+
 typedef struct msgpack_packer {
     char *buf;
     size_t length;

--- a/python/msgpack/pack_template.h
+++ b/python/msgpack/pack_template.h
@@ -555,8 +555,8 @@ if(sizeof(unsigned long long) == 2) {
 msgpack_pack_inline_func(_float)(msgpack_pack_user x, float d)
 {
 	union { char buf[4]; uint32_t num; } f;
-	*((float*)&f.buf) = d;  // FIXME
 	unsigned char buf[5];
+	*((float*)&f.buf) = d;  // FIXME
 	buf[0] = 0xca; *(uint32_t*)&buf[1] = _msgpack_be32(f.num);
 	msgpack_pack_append_buffer(x, buf, 5);
 }
@@ -564,8 +564,8 @@ msgpack_pack_inline_func(_float)(msgpack_pack_user x, float d)
 msgpack_pack_inline_func(_double)(msgpack_pack_user x, double d)
 {
 	union { char buf[8]; uint64_t num; } f;
-	*((double*)&f.buf) = d;  // FIXME
 	unsigned char buf[9];
+	*((double*)&f.buf) = d;  // FIXME
 	buf[0] = 0xcb; *(uint64_t*)&buf[1] = _msgpack_be64(f.num);
 	msgpack_pack_append_buffer(x, buf, 9);
 }

--- a/python/msgpack/unpack_template.h
+++ b/python/msgpack/unpack_template.h
@@ -82,8 +82,6 @@ msgpack_unpack_func(msgpack_unpack_object, _data)(msgpack_unpack_struct(_context
 
 msgpack_unpack_func(int, _execute)(msgpack_unpack_struct(_context)* ctx, const char* data, size_t len, size_t* off)
 {
-	assert(len >= *off);
-
 	const unsigned char* p = (unsigned char*)data + *off;
 	const unsigned char* const pe = (unsigned char*)data + len;
 	const void* n = NULL;
@@ -91,6 +89,7 @@ msgpack_unpack_func(int, _execute)(msgpack_unpack_struct(_context)* ctx, const c
 	unsigned int trail = ctx->trail;
 	unsigned int cs = ctx->cs;
 	unsigned int top = ctx->top;
+
 	msgpack_unpack_struct(_stack)* stack = ctx->stack;
 	msgpack_unpack_user* user = &ctx->user;
 
@@ -98,6 +97,8 @@ msgpack_unpack_func(int, _execute)(msgpack_unpack_struct(_context)* ctx, const c
 	msgpack_unpack_struct(_stack)* c = NULL;
 
 	int ret;
+
+	assert(len >= *off);
 
 #define push_simple_value(func) \
 	if(msgpack_unpack_callback(func)(user, &obj) < 0) { goto _failed; } \


### PR DESCRIPTION
Fixed VisualStudio compiler errors: __inline instead of inline and local variables always defined before code.
