### PR TITLE
phpextension - Fix include path for php_version.h affecting Ubuntu users

### DIFF
--- a/php/config.m4
+++ b/php/config.m4
@@ -7,7 +7,7 @@ dnl without editing.
 dnl Check PHP version:
 
 AC_MSG_CHECKING(PHP version)
-AC_TRY_COMPILE([#include "php/main/php_version.h"], [
+AC_TRY_COMPILE([#include "$phpincludedir/main/php_version.h"], [
 #if PHP_MAJOR_VERSION < 5
 #error  this extension requires at least PHP version 5 or newer
 #endif


### PR DESCRIPTION
In ubuntu php is located at ie. "/usr/include/php5/" not "/usr/include/php/" as some other systems, this leads to a configure error: "need at least PHP 5 or newer". Using the $phpincludedir variables seems to resolve the issue. 
