### PR TITLE
fixed Go bindings

### DIFF
--- a/go/unpack.go
+++ b/go/unpack.go
@@ -6,7 +6,7 @@ import (
 	"unsafe"
 	"strconv"
 	"reflect"
-        "fmt"
+	"fmt"
 )
 
 func readByte(reader io.Reader) (v uint8, err os.Error) {
@@ -150,7 +150,7 @@ func unpack(reader io.Reader, reflected bool) (v reflect.Value, n int, err os.Er
 	if e != nil {
 		return reflect.Value{}, 0, e
 	}
-        fmt.Printf("unpack byte: %x\n", c)
+	fmt.Printf("unpack byte: %x\n", c)
 	nbytesread += 1
 	if c < 0x80 || c >= 0xe0 {
 		retval = reflect.ValueOf(int8(c))


### PR DESCRIPTION
I fixed the go bindings for msgpack to compile, and I also fixed a bug in the unpacking of "fix raw" bytes...the existing code in master gets the size of the bytes wrong (c & 0xf [wrong] vs. c & 0x1f [right]).
