### PR TITLE
Go string support

### DIFF
--- a/go/msgpack_test.go
+++ b/go/msgpack_test.go
@@ -254,13 +254,13 @@ func TestPackMap(t *testing.T) {
 
 func TestPack(t *testing.T) {
 	b := &bytes.Buffer{}
-	for _, i := range [](interface{}){nil, false, true, 0, 1, 2, 3, 127, -32, -1, -33, 128} {
+	for _, i := range [](interface{}){nil, false, true, 0, 1, 2, 3, 127, -32, -1, -33, 128, "astring"} {
 		_, err := Pack(b, i)
 		if err != nil {
 			t.Error("err != nil")
 		}
 	}
-	if bytes.Compare(b.Bytes(), []byte{0xc0, 0xc2, 0xc3, 0x00, 0x01, 0x02, 0x03, 0x7f, 0xf0, 0xff, 0xd0, 0xef, 0xd1, 0x00, 0x80}) == 0 {
+	if bytes.Compare(b.Bytes(), []byte{0xc0, 0xc2, 0xc3, 0x00, 0x01, 0x02, 0x03, 0x7f, 0xe0, 0xff, 0xd0, 0xdf, 0xd1, 0x00, 0x80, 0xA7, 'a', 's', 't', 'r', 'i', 'n', 'g'}) != 0 {
 		t.Error("wrong output")
 	}
 }

--- a/go/pack.go
+++ b/go/pack.go
@@ -699,6 +699,8 @@ func PackValue(writer io.Writer, value reflect.Value) (n int, err os.Error) {
 		return PackArray(writer, _value)
 	case reflect.Map:
 		return PackMap(writer, _value)
+	case reflect.String:
+		return PackBytes(writer, []byte(_value.String()))
 	case reflect.Interface:
 		__value := reflect.ValueOf(_value.Interface())
 
@@ -765,6 +767,8 @@ func Pack(writer io.Writer, value interface{}) (n int, err os.Error) {
 		return PackFloat32Array(writer, _value)
 	case []float64:
 		return PackFloat64Array(writer, _value)
+	case string:
+		return PackBytes(writer, []byte(_value))
 	default:
 		return PackValue(writer, reflect.ValueOf(value))
 	}


### PR DESCRIPTION
Added some simple string support to the Go library.  Added a string example to the Pack test.  Also, the Pack test was broken (comparing wrong values) and always passing so I fixed it.  The correct byte values were checked against the ruby implementation.
