### PR TITLE
Fix for valgrind's "Mismatched free() / delete / delete []" during streaming deserialization

### DIFF
--- a/cpp/src/msgpack/unpack.hpp
+++ b/cpp/src/msgpack/unpack.hpp
@@ -226,12 +226,12 @@ inline bool unpacker::next(unpacked* result)
 	}
 
 	if(ret == 0) {
-		result->zone().reset();
+		if (result->zone().get() != 0) result->zone().reset();
 		result->get() = object();
 		return false;
 
 	} else {
-		result->zone().reset( release_zone() );
+		if (result->zone().get() != 0) result->zone().reset( release_zone() );
 		result->get() = data();
 		reset();
 		return true;


### PR DESCRIPTION
When running the [streaming deserialization example](http://wiki.msgpack.org/pages/viewpage.action?pageId=1081387#QuickStartforC%2B%2B-Streamingfeature) through valgrind you get warnings about "Mismatched free() / delete / delete []". Issue #77 also references this error.

It's easy to fix, just don't reset if the auto_ptr contains a null pointer.
