### PR TITLE
.NET Property support.

### DIFF
--- a/csharp/MsgPack/CompiledPacker.cs
+++ b/csharp/MsgPack/CompiledPacker.cs
@@ -372,6 +372,7 @@ namespace MsgPack
 				BindingFlags baseFlags = BindingFlags.Instance | BindingFlags.Public;
 				List<MemberInfo> list = new List<MemberInfo> ();
 				list.AddRange (t.GetFields (baseFlags));
+				list.AddRange( t.GetProperties(baseFlags));
 				// TODO: Add NonSerialized Attribute Filter ?
 				return list.ToArray ();
 			}


### PR DESCRIPTION
You know how .NET loves properties over fields.

This simple patch (one line), allows the compiled packer to support properties.

I'm using this code in production :)

I hope you find it useful.

Javier.
