### PR TITLE
csharp: fix bug, which is cause of FormatException in case of RawStrings longer than 64 bytes

### DIFF
--- a/csharp/MsgPack/MsgPackReader.cs
+++ b/csharp/MsgPack/MsgPackReader.cs
@@ -248,10 +248,11 @@ namespace MsgPack
 				return _encoding.GetString (buf, 0, (int)this.Length);
 			}
 
-			// Poor implementation
 			byte[] tmp = new byte[(int)this.Length];
-			if (ReadValueRaw (tmp, 0, tmp.Length) != tmp.Length)
-				throw new FormatException ();
+			int read_len = 0;
+			while (read_len != tmp.Length)
+				read_len += ReadValueRaw (tmp, read_len, tmp.Length - read_len);
+			
 			return _encoding.GetString (tmp);
 		}
 	}


### PR DESCRIPTION
Heisenbug: in case of a slow stream (network socket, for example), the buffer is read faster than it is written to.  In case of strings longer than 64 bytes (buffer size on writing side), the remainder of the bytes is not received in time. C# streams may fill the buffer to the specified length, but may fill it with less bytes, as specified by the return-value of Stream.Read.

Fix waits for the entire buffer to be filled, instead of assuming that the stream fills the entire buffer at once.
