### PR TITLE
Added gcc pragma to msgpack.h

### DIFF
--- a/cpp/src/msgpack.h
+++ b/cpp/src/msgpack.h
@@ -20,6 +20,9 @@
  * @{
  * @}
  */
+
+#pragma GCC diagnostic ignored "-Wunused-function"
+
 #include "msgpack/object.h"
 #include "msgpack/zone.h"
 #include "msgpack/pack.h"


### PR DESCRIPTION
to avoid warnings of the kind:

include/msgpack/unpack.h:224:8: warning: unused
function
      'msgpack_unpacker_parsed_size' [-Wunused-function]
      size_t msgpack_unpacker_parsed_size(const msgpack_unpacker\* mpac)

when including msgpack.h and compiling with -Wall
