### PR TITLE
c: supports DLL generation by MinGW

### DIFF
--- a/cpp/src/Makefile.am
+++ b/cpp/src/Makefile.am
@@ -20,7 +20,7 @@ endif
 
 
 # -version-info CURRENT:REVISION:AGE
-libmsgpack_la_LDFLAGS = -version-info 3:0:0
+libmsgpack_la_LDFLAGS = -version-info 3:0:0 -no-undefined
 
 
 # backward compatibility
@@ -33,7 +33,7 @@ libmsgpackc_la_SOURCES = \
 		vrefbuffer.c \
 		zone.c
 
-libmsgpackc_la_LDFLAGS = -version-info 2:0:0
+libmsgpackc_la_LDFLAGS = -version-info 2:0:0 -no-undefined
 
 
 nobase_include_HEADERS = \


### PR DESCRIPTION
libtool requires -no-undefined link option to generate a DLL
by MinGW. A DLL should not have any unresolved symbols and
-no-undefined link option declares that the library doesn't
depends on any libraries other than the ones listed on the
command line.

See also: description about -no-undefined option at
http://www.gnu.org/software/libtool/manual/libtool.html#Link-mode
