### PR TITLE
c: supports pkg-config

### DIFF
--- a/cpp/Makefile.am
+++ b/cpp/Makefile.am
@@ -13,6 +13,9 @@ DOC_FILES = \
 EXTRA_DIST = \
 		$(DOC_FILES)
 
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = msgpack.pc
+
 doxygen:
 	./preprocess clean
 	cd src && $(MAKE) doxygen

--- a/cpp/configure.in
+++ b/cpp/configure.in
@@ -93,6 +93,7 @@ AC_SUBST(VERSION_MINOR, $minor)
 
 
 AC_OUTPUT([Makefile
+		   msgpack.pc
 		   src/Makefile
 		   src/msgpack/version.h
 		   test/Makefile])

--- a/cpp/msgpack.pc.in
+++ b/cpp/msgpack.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: MessagePack
+Description: Binary-based efficient object serialization library
+Version: @VERSION@
+Libs: -L${libdir} -lmsgpack
+Cflags: -I${includedir}


### PR DESCRIPTION
About pkg-config:

  From http://www.freedesktop.org/wiki/Software/pkg-config

  pkg-config is a helper tool used when compiling applications and
  libraries. It helps you insert the correct compiler options on the
  command line so an application can use gcc -o test test.c
  `pkg-config --libs --cflags glib-2.0` for instance, rather than
  hard-coding values on where to find glib (or other libraries). It is
  language-agnostic, so it can be used for defining the location of
  documentation tools, for instance.

pkg-config is a widely used build helper tool. Major build tools such
as GNU Autoconf, CMake and so on support pkg-config.

MessagePack users can build their software more easily.
