### PR TITLE
Fix build with PHP-5.4

### DIFF
--- a/php/msgpack.c
+++ b/php/msgpack.c
@@ -140,7 +140,11 @@ PS_SERIALIZER_ENCODE_FUNC(msgpack)
 
     PHP_VAR_SERIALIZE_INIT(var_hash);
 
+#if (PHP_MAJOR_VERSION == 5 && PHP_MINOR_VERSION < 4)
     msgpack_serialize_zval(&buf, PS(http_session_vars), &var_hash TSRMLS_CC);
+#else
+    msgpack_serialize_zval(&buf, PS(http_session_vars), var_hash TSRMLS_CC);
+#endif
 
     if (newlen)
     {
@@ -167,7 +171,7 @@ PS_SERIALIZER_DECODE_FUNC(msgpack)
     zval **value;
     size_t off = 0;
     msgpack_unpack_t mp;
-    php_unserialize_data_t var_hash;
+    struct php_unserialize_data var_hash;
 
     ALLOC_INIT_ZVAL(tmp);
 
@@ -176,7 +180,7 @@ PS_SERIALIZER_DECODE_FUNC(msgpack)
     msgpack_unserialize_var_init(&var_hash);
 
     mp.user.retval = (zval *)tmp;
-    mp.user.var_hash = (php_unserialize_data_t *)&var_hash;
+    mp.user.var_hash = (struct php_unserialize_data *)&var_hash;
 
     ret = template_execute(&mp, (char *)val, (size_t)vallen, &off);
 
@@ -223,7 +227,11 @@ PHP_MSGPACK_API void php_msgpack_serialize(smart_str *buf, zval *val TSRMLS_DC)
 
     PHP_VAR_SERIALIZE_INIT(var_hash);
 
+#if (PHP_MAJOR_VERSION == 5 && PHP_MINOR_VERSION < 4)
     msgpack_serialize_zval(buf, val, &var_hash TSRMLS_CC);
+#else
+    msgpack_serialize_zval(buf, val, var_hash TSRMLS_CC);
+#endif
 
     PHP_VAR_SERIALIZE_DESTROY(var_hash);
 }
@@ -234,7 +242,7 @@ PHP_MSGPACK_API void php_msgpack_unserialize(
     int ret;
     size_t off = 0;
     msgpack_unpack_t mp;
-    php_unserialize_data_t var_hash;
+    struct php_unserialize_data var_hash;
 
     if (str_len <= 0)
     {
@@ -246,7 +254,7 @@ PHP_MSGPACK_API void php_msgpack_unserialize(
     msgpack_unserialize_var_init(&var_hash);
 
     mp.user.retval = (zval *)return_value;
-    mp.user.var_hash = (php_unserialize_data_t *)&var_hash;
+    mp.user.var_hash = (struct php_unserialize_data *)&var_hash;
 
     ret = template_execute(&mp, str, (size_t)str_len, &off);
 

--- a/php/msgpack_unpack.c
+++ b/php/msgpack_unpack.c
@@ -54,7 +54,7 @@ typedef struct
     MSGPACK_UNSERIALIZE_FINISH_ITEM(_unpack, 2);
 
 inline static void msgpack_var_push(
-    php_unserialize_data_t *var_hashx, zval **rval)
+    struct php_unserialize_data *var_hashx, zval **rval)
 {
     var_entries *var_hash, *prev = NULL;
 
@@ -91,7 +91,7 @@ inline static void msgpack_var_push(
 }
 
 inline static int msgpack_var_access(
-    php_unserialize_data_t *var_hashx, long id, zval ***store)
+    struct php_unserialize_data *var_hashx, long id, zval ***store)
 {
     var_entries *var_hash = var_hashx->first;
 
@@ -118,7 +118,7 @@ inline static int msgpack_var_access(
 }
 
 inline static void msgpack_stack_push(
-    php_unserialize_data_t *var_hashx, zval **rval, zend_bool save)
+    struct php_unserialize_data *var_hashx, zval **rval, zend_bool save)
 {
     var_entries *var_hash, *prev = NULL;
 
@@ -162,7 +162,7 @@ inline static void msgpack_stack_push(
 }
 
 inline static void msgpack_stack_pop(
-    php_unserialize_data_t *var_hashx, long count)
+    struct php_unserialize_data *var_hashx, long count)
 {
     long i;
     var_entries *var_hash = var_hashx->first_dtor;
@@ -280,14 +280,14 @@ inline static zend_class_entry* msgpack_unserialize_class(
     return ce;
 }
 
-void msgpack_unserialize_var_init(php_unserialize_data_t *var_hashx)
+void msgpack_unserialize_var_init(struct php_unserialize_data *var_hashx)
 {
     var_hashx->first = 0;
     var_hashx->first_dtor = 0;
 }
 
 void msgpack_unserialize_var_destroy(
-    php_unserialize_data_t *var_hashx, zend_bool err)
+    struct php_unserialize_data *var_hashx, zend_bool err)
 {
     void *next;
     long i;

--- a/php/msgpack_unpack.h
+++ b/php/msgpack_unpack.h
@@ -19,14 +19,14 @@ typedef enum
 typedef struct {
     zval *retval;
     long deps;
-    php_unserialize_data_t *var_hash;
+    struct php_unserialize_data *var_hash;
     long stack[MSGPACK_EMBED_STACK_SIZE];
     int type;
 } msgpack_unserialize_data;
 
-void msgpack_unserialize_var_init(php_unserialize_data_t *var_hashx);
+void msgpack_unserialize_var_init(struct php_unserialize_data *var_hashx);
 void msgpack_unserialize_var_destroy(
-    php_unserialize_data_t *var_hashx, zend_bool err);
+    struct php_unserialize_data *var_hashx, zend_bool err);
 
 void msgpack_unserialize_init(msgpack_unserialize_data *unpack);
 


### PR DESCRIPTION
Hi:
   I am laruence,  PHP internal developer. 

   msgpack for PHP can not build with PHP 5.4 before, I fix it.

   PS:  rencently I wrote a RPC framework http://pecl.php.net/package/yar , which use msgpack as one of it's packager protocols. so, how about list msgpack into pecl too?

thanks
