### PR TITLE
Provide version numbers for the old and new specifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@ MessagePack
 
 MessagePack is an efficient binary serialization format. It's like JSON. but fast and small.
 
-This repository manages specification of MessagePack format. See [Spec](spec.md) for the specification.
+This repository manages the specification of the MessagePack format.
+The current specification is [Version 2.0](spec.md). The older [Version 1.0](spec-old.md) specification is also available.
 
 Implementation projects have each own repository. See [msgpack.org](http://msgpack.org/) website to find implementations and their documents.
 

--- a/spec-old.md
+++ b/spec-old.md
@@ -1,6 +1,6 @@
-# MessagePack format specification
+# MessagePack specification v1.0
 
-**This spec is updated. See [spec.md](spec.md) for the updated version.**
+**This specification has been replaced by [Version 2.0](spec.md).**
 
 
 MessagePack saves type-information to the serialized data. Thus each data is stored in **type-data** or **type-length-data** style.

--- a/spec.md
+++ b/spec.md
@@ -1,4 +1,4 @@
-# MessagePack specification
+# MessagePack specification v2.0
 
 MessagePack is an object serialization specification like JSON.
 


### PR DESCRIPTION
Providing version numbers is good software practice.
This change will be appreciated by all users of MessagePack.
Fixes msgpack/msgpack#162
