### PR TITLE
Fixes to timestamp possible range

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -445,8 +445,8 @@ Timestamp extension type is assigned to extension type `-1`. It defines 3 format
     +--------+--------+--------+--------+--------+--------+--------+--------+
 
 * Timestamp 32 format can represent a timestamp in [1970-01-01 00:00:00 UTC, 2106-02-07 06:28:16 UTC) range. Nanoseconds part is 0.
-* Timestamp 64 format can represent a timestamp in [1970-01-01 00:00:00.000000000 UTC, 2514-05-30 01:53:04.000000000 UTC) range.
-* Timestamp 96 format can represent a timestamp in [-584554047284-02-23 16:59:44 UTC, 584554051223-11-09 07:00:16.000000000 UTC) range.
+* Timestamp 64 format can represent a timestamp in [1970-01-01 00:00:00.000000000 UTC, 2514-05-30 01:53:04.999999999 UTC) range.
+* Timestamp 96 format can represent a timestamp in [-584554047284-02-23 16:59:44 UTC, 584554051223-11-09 07:00:16.999999999 UTC) range.
 * In timestamp 64 and timestamp 96 formats, nanoseconds must not be larger than 999999999.
 
 Pseudo code for serialization:


### PR DESCRIPTION
This is easy to overlook, but nanoseconds increase the upper bound.