### PR TITLE
Fix incorrectly specified range of 64bit timestamps

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -444,7 +444,7 @@ Timestamp extension type is assigned to extension type `-1`. It defines 3 format
 
 * Timestamp 32 format can represent a timestamp in [1970-01-01 00:00:00 UTC, 2106-02-07 06:28:16 UTC) range. Nanoseconds part is 0.
 * Timestamp 64 format can represent a timestamp in [1970-01-01 00:00:00.000000000 UTC, 2514-05-30 01:53:04.000000000 UTC) range.
-* Timestamp 96 format can represent a timestamp in [-584554047284-02-23 16:59:44 UTC, 584554051223-11-09 07:00:16.000000000 UTC) range.
+* Timestamp 96 format can represent a timestamp in [-292277022657-01-27 08:29:52 UTC, 292277026596-12-04 15:30:08.000000000 UTC) range.
 * In timestamp 64 and timestamp 96 formats, nanoseconds must not be larger than 999999999.
 
 Pseudo code for serialization:


### PR DESCRIPTION
The currently specified range

    [-584554047284-02-23 16:59:44 UTC, 584554051223-11-09 07:00:16 UTC)

implies a range of ~3.7e19 seconds; however, if have only 64bit to encode an amount of seconds you can only represent amounts up to 18446744073709551615 seconds (i.e. ~1.8e19).

Consequently, the correct range when using a signed 64-bit integer to represent seconds is

    [-292277022657-01-27 08:29:52 UTC, 292277026596-12-04 15:30:08 UTC)