### PR TITLE
fix timestamp 96's nanoseconds to be signed, not unsigned, to take negative values

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -436,7 +436,7 @@ Timestamp extension type is assigned to extension type `-1`. It defines 3 format
     timestamp 96 stores the number of seconds and nanoseconds that have elapsed since 1970-01-01 00:00:00 UTC
     in 64-bit signed integer and 32-bit unsigned integer:
     +--------+--------+--------+--------+--------+--------+--------+
-    |  0xc7  |   12   |   -1   |nanoseconds in 32-bit unsigned int |
+    |  0xc7  |   12   |   -1   |nanoseconds in 32-bit signed int   |
     +--------+--------+--------+--------+--------+--------+--------+
     +--------+--------+--------+--------+--------+--------+--------+--------+
                         seconds in 64-bit signed int                        |


### PR DESCRIPTION
The current spec says timestamp 96's nanosecond field is 32-bit unsigned integer, but it must be signed 32-bit int, I believe. Otherwise, timestamps cannot represent `epoc - 1 nanoseconds`(i.e. `{ sec = 0, nsec = -1 } == 1969-12-31T23:59:59.999999999Z`).

Because nanoseconds itself requires just 30-bit int, the PR won't break backward compatibility, anyway.