### PR TITLE
Add support for typed N-D array to simplify large array storage

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -102,7 +102,7 @@ fixmap          | 1000xxxx               | 0x80 - 0x8f
 fixarray        | 1001xxxx               | 0x90 - 0x9f
 fixstr          | 101xxxxx               | 0xa0 - 0xbf
 nil             | 11000000               | 0xc0
-(never used)    | 11000001               | 0xc1
+typed N-D array | 11000001               | 0xc1
 false           | 11000010               | 0xc2
 true            | 11000011               | 0xc3
 bin 8           | 11000100               | 0xc4
@@ -329,11 +329,21 @@ Array format family stores a sequence of elements in 1, 3, or 5 bytes of extra b
     |  0xdd  |ZZZZZZZZ|ZZZZZZZZ|ZZZZZZZZ|ZZZZZZZZ|    N objects    |
     +--------+--------+--------+--------+--------+~~~~~~~~~~~~~~~~~+
 
+    typed N-D array stores a array with a specified data type and lengths in upto (2^8)-1 dimensions
+    +--------+--------+--------+====================================+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~+
+    |  0xc1  |  type  |  dim   | dim uint32 integers (N1,N2,...,ND) |    N1*N2*...*ND typed values  |
+    +--------+--------+--------+====================================+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~+
+
     where
     * XXXX is a 4-bit unsigned integer which represents N
     * YYYYYYYY_YYYYYYYY is a 16-bit big-endian unsigned integer which represents N
     * ZZZZZZZZ_ZZZZZZZZ_ZZZZZZZZ_ZZZZZZZZ is a 32-bit big-endian unsigned integer which represents N
     * N is the size of an array
+    * type is an 8-bit big-endian unsigned integer, specifying the data type of the array
+    * if type is between 0xca and 0xd3, the specified type can be found in the Summary section;
+    * other type values are reserved for future extension of this specification.
+    * dim is an 8-bit big-endian unsigned integer, specifying the dimensions of the array
+    * N1, N2, ..., ND are big-endian uint32 integers, specifying the length of the array along each of the D dimension
 
 ### map format family
 


### PR DESCRIPTION
A simple header to speedup reading/writing large N-D arrays and save space. Particularly useful when processing 2D image data and 3D or high dimension data form scientific research.

A similar array header was supported by [UBJSON](http://ubjson.org/type-reference/container-types/#optimized-format) and its extensions to N-D array in the [JData specification draft](https://github.com/fangq/jdata/blob/master/JData_specification.md#binary-jdata-storage-grammar). A similar and strong need from the UBJSON user community of such feature was discussed previously [here](https://github.com/ubjson/universal-binary-json/issues/61).

