### PR TITLE
Use "fixint" instead of "fixnum", since "fixint" is used in the rest of the document

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -181,12 +181,12 @@ Bool format family stores false or true in 1 byte.
 
 Int format family stores an integer in 1, 2, 3, 5, or 9 bytes.
 
-    positive fixnum stores 7-bit positive integer
+    positive fixint stores 7-bit positive integer
     +--------+
     |0XXXXXXX|
     +--------+
 
-    negative fixnum stores 5-bit negative integer
+    negative fixnint stores 5-bit negative integer
     +--------+
     |111YYYYY|
     +--------+
@@ -388,7 +388,7 @@ Ext format family stores a tuple of an integer and a byte array.
 
     fixext 16 stores an integer and a byte array whose length is 16 bytes
     +--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+
-    |  0xd8  |  type  |                                  data                                  
+    |  0xd8  |  type  |                                  data
     +--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+
     +--------+--------+--------+--------+--------+--------+--------+--------+
                                   data (cont.)                              |


### PR DESCRIPTION
Hi,

I was trying to write an implementation of MessagePack, following this spec, but when searching the document, I could not find out where `fixint` was specified.

Turns out the word `fixnum` was used in two places instead of `fixint` (which is used in the rest of the document).

Thanks for creating MessagePack!

Best regards,
Alexander F. Rødseth