### PR TITLE
Make spec versioning explicit

### DIFF
--- a/spec-old.md
+++ b/spec-old.md
@@ -1,6 +1,6 @@
-# MessagePack format specification
+# MessagePack format specification - 2011
 
-**This spec is updated. See [spec.md](spec.md) for the updated version.**
+**This is the old 2011 version of the spec. See [spec.md](spec.md) for the updated and stable 2013 version.**
 
 
 MessagePack saves type-information to the serialized data. Thus each data is stored in **type-data** or **type-length-data** style.

--- a/spec.md
+++ b/spec.md
@@ -538,12 +538,12 @@ For example, applications may remove Binary type, restrict keys of map objects t
 
 ### Upgrading MessagePack specification
 
-MessagePack specification is changed at this time.
-Here is a guideline to upgrade existent MessagePack implementations:
+This is the current and stable version of the spec, established in 2013. There is one [older version](spec-old.md) from 2011.
+Here is a guideline for upgrading older MessagePack implementations to be compatible with the current spec:
 
-* In a minor release, deserializers support the bin format family and str 8 format. The type of deserialized objects should be same with raw 16 (== str 16) or raw 32 (== str 32)
-* In a major release, serializers distinguish Binary type and String type using bin format family and str format family
-  * At the same time, serializers should offer "compatibility mode" which doesn't use bin format family and str 8 format
+1. In a minor release, deserializers add support for the bin format family and str 8 format. The type of deserialized objects should be same with raw 16 (== str 16) or raw 32 (== str 32)
+2. In a major release, serializers distinguish Binary type and String type using bin format family and str format family
+  * At the same time, serializers should offer "compatibility mode" for the older spec version which doesn't use bin format family and str 8 format
 
 
 ___


### PR DESCRIPTION
The relationship of the old and new specs was not entirely clear, and the
spec versions did not have names to refer to them by; implementors can now
indicate which version they support, if needed.

This commit establishes the year of release as the version name, makes
it clear that the 2013 version is the current and stable one, and hints
that support for the 2011 version is not necessary in new implementations.

(Also includes some minor language clarifications.)