### PR TITLE
Introduce Length Encoding extension as -2

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -492,6 +492,28 @@ Pseudo code for deserialization:
          // error
      }
 
+### Length encoding extension type
+
+Wrapping maps and arrays in extension type `-2` benefits partial decoders that want to skip over values.
+
+Encoders MAY wrap arrays and maps by prefixing their msgdata data with an ext / fixext header with the type `-2`. Encoders MAY NOT wrap any other types.
+
+When encountering extension data of type `-2`, decoders can simply skip 2 bytes ahead for fixext data and skip 2, 3, 4 or 6 bytes ahead for ext.
+
+Decoders wanting to skip an entire value can skip ahead as they would for any extension type.
+
+Two examples:
+
+    Using a fixext 2 to store an array of one 1 byte element.
+    +--------+--------+--------+--------+
+    |  0xd5  |   -2   |  0x91  |  data  |
+    +--------+--------+--------+--------+
+
+    Using a fixext 4 to store a map with {"x": true}.
+    +--------+--------+--------+--------+--------+--------+
+    |  0xd6  |   -2   |  0x81  |  0xa1  |  0x78  |  0xc3  |
+    +--------+--------+--------+--------+--------+--------+
+
 ## Serialization: type to format conversion
 
 MessagePack serializers convert MessagePack types into formats as following:


### PR DESCRIPTION
Partial decoders can greatly benefit from being able to skip over (large) arrays and maps faster. Currently this process requires iterating through all (keys and) values of the map/array recursively, decoding all of them (at least, decoding enough of the data to decide on their length).

Extension types neatly include their size, which makes them easy to skip over because their size in bytes is known early.

Encoders can choose to ignore this extension completely. The implementation for decoders is fairly simply because it just requires skipping 2/3/4 or 6 bytes ahead in the input stream and continuing as normal.
Obviously, encoders using this should not be used with decoders that don't support it.

We've been using this technique in my company for ~6 months and it's been very effective in speeding up partial decoding of large, nested msgpack values.

We have a function that parses and rewrites msgpack to wrap arrays and maps with this extension type in places where we have write-once read many situations.

Given the goal of speeding up decoders, I propose to make it only legal to wrap arrays and maps as other types are cheap enough to decode the length of. Decoders could optionally support it, but encoders shouldn't wrap those. Future compatibility with this requirement is unlikely to be an issue, because future spec changes would likely be extensions which can already be skipped over cheaply.